### PR TITLE
cedric: Do not start livedisplay in the first boot

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -221,7 +221,8 @@ PRODUCT_PACKAGES += \
     init.qcom.ril.sh \
     init.qcom.bt.sh \
     init.qcom.fm.sh \
-    wlan_carrier_bin.sh
+    wlan_carrier_bin.sh \
+    init.livedisplay.sh
 
 PRODUCT_PACKAGES += \
     fstab.qcom \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -63,6 +63,14 @@ LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES    := etc/init.qcom.ril.sh
 include $(BUILD_PREBUILT)
 
+include $(CLEAR_VARS)
+LOCAL_MODULE       := init.livedisplay.sh
+LOCAL_MODULE_TAGS  := optional eng
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES    := etc/init.livedisplay.sh
+LOCAL_MODULE_PATH  := $(TARGET_ROOT_OUT)
+include $(BUILD_PREBUILT)
+
 # Init scripts
 
 include $(CLEAR_VARS)

--- a/rootdir/etc/init.livedisplay.sh
+++ b/rootdir/etc/init.livedisplay.sh
@@ -1,0 +1,3 @@
+export PATH=/system/xbin:$PATH
+
+settings put system display_temperature_mode 0

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -839,6 +839,14 @@ service ssr_setup /system/bin/ssr_setup
 on property:persist.sys.ssr.restart_level=*
     start ssr_setup
 
+service stopld /system/bin/sh /init.livedisplay.sh
+    class main
+    user root
+    oneshot
+
+on property:sys.boot_completed=1
+    start stopld
+
 on charger
     wait /dev/block/bootdevice/by-name/system
     mount ext4 /dev/block/bootdevice/by-name/system /system ro barrier=1


### PR DESCRIPTION
It decreases device's performance highly. Let's just make it stop in the first boot.
The users can turn it on from settings if they want.